### PR TITLE
We let Dependabot be its own biggest fan and keep GHA up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/pr-dependabot-auto-approve.yml
+++ b/.github/workflows/pr-dependabot-auto-approve.yml
@@ -1,0 +1,17 @@
+name: Dependabot Auto Approve
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot-auto-approve:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Auto Approve Dependabot PRs
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/pr-dependabot-auto-merge.yml
+++ b/.github/workflows/pr-dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable Auto Merge for Dependabot PRs
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
* Take care of GHA daily
* Autoapprove PRs from Dependabot
* Flag PRs from Dependabot as automergeable