### PR TITLE
Only install dev dependencies in the uv run based CI jobs

### DIFF
--- a/.github/workflows/push-format-python.yml
+++ b/.github/workflows/push-format-python.yml
@@ -21,4 +21,4 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: ruff format check
-        run: uv run --locked ruff format --check
+        run: uv run --locked --only-dev ruff format --check

--- a/.github/workflows/push-lint-markdown.yml
+++ b/.github/workflows/push-lint-markdown.yml
@@ -21,4 +21,4 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: markdownlint
-        run: uv run --locked pymarkdown scan .
+        run: uv run --locked --only-dev pymarkdown scan .

--- a/.github/workflows/push-lint-python.yml
+++ b/.github/workflows/push-lint-python.yml
@@ -21,4 +21,4 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: ruff check
-        run: uv run --locked ruff check
+        run: uv run --locked --only-dev ruff check


### PR DESCRIPTION
This landed in uv 0.4.11: https://github.com/astral-sh/uv/releases/tag/0.4.11

Speeding the CI up for the linter and formatting jobs.