### PR TITLE
Trim spurious newlines from the smoketest script output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ $ ./smoketest.sh
 
 cogvideox.py
 
-
 real 4m3.882s
 user 2m4.826s
 sys 1m43.195s
 
 flux-dev-16.py
-
 
 real 6m19.258s
 user 4m49.680s
@@ -58,13 +56,11 @@ sys 1m18.687s
 
 flux-dev-8.py
 
-
 real 5m32.990s
 user 9m19.441s
 sys 4m32.792s
 
 flux-schnell-16.py
-
 
 real 0m48.955s
 user 0m25.809s
@@ -72,13 +68,11 @@ sys 0m14.294s
 
 flux-schnell-8.py
 
-
 real 2m9.099s
 user 7m9.572s
 sys 2m21.556s
 
 latte-1.py
-
 
 real 0m58.887s
 user 1m0.014s
@@ -86,13 +80,11 @@ sys 0m30.556s
 
 sa-10.py
 
-
 real 0m58.454s
 user 1m5.611s
 sys 0m3.884s
 
 sd-21.py
-
 
 real 0m53.635s
 user 0m50.140s
@@ -100,13 +92,11 @@ sys 0m15.909s
 
 sd-30.py
 
-
 real 0m49.789s
 user 1m0.705s
 sys 0m25.067s
 
 sd-turbo.py
-
 
 real 0m13.490s
 user 0m24.089s

--- a/smoketest.sh
+++ b/smoketest.sh
@@ -6,7 +6,6 @@ time (
     do
         echo ""
         echo "${script}"
-        echo ""
         time uv run --locked "${script}" --no-open-outputs &> /dev/null
     done
 )


### PR DESCRIPTION
Did not think of `time` already adding the "trailing newline" to the output.